### PR TITLE
Adds compatibility with Node 4.0.0 up to 4.4.7. Buffer.from is available since 4.5

### DIFF
--- a/lib/encrypted-attr.js
+++ b/lib/encrypted-attr.js
@@ -4,6 +4,7 @@ const alg = 'aes-256-gcm'
 const crypto = require('crypto')
 const get = require('lodash').get
 const set = require('lodash').set
+const Buffer = require('safe-buffer').Buffer
 
 function EncryptedAttributes (attributes, options) {
   options = options || {}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "orm"
   ],
   "dependencies": {
-    "lodash": "^4.17.4"
+    "lodash": "^4.17.4",
+    "safe-buffer": "^5.1.1"
   },
   "devDependencies": {
     "mocha": "^3.5.0",


### PR DESCRIPTION
Adds compatibility with Node 4.0.0 up to 4.4.7. Buffer.from is available since 4.5

https://nodejs.org/docs/v4.5.0/api/buffer.html#buffer_new_buffer_str_encoding